### PR TITLE
Implicit casts made explicit to suppress compiler warnings

### DIFF
--- a/src/heart_rate_monitor-shared.c
+++ b/src/heart_rate_monitor-shared.c
@@ -88,17 +88,17 @@ int hrm_get_history(heart_rate_monitor_t volatile * hb,
   if(hb->state->counter > hb->state->buffer_index) {
      memcpy(record,
 	    &hb->log[hb->state->buffer_index],
-	    (hb->state->buffer_index*hb->state->buffer_depth)*sizeof(heartbeat_record_t));
+	    (size_t)(hb->state->buffer_index*hb->state->buffer_depth)*sizeof(heartbeat_record_t));
      memcpy(record + (hb->state->buffer_index*hb->state->buffer_depth),
 	    &hb->log[0],
-	    (hb->state->buffer_index)*sizeof(heartbeat_record_t));
-     return hb->state->buffer_depth;
+	    (size_t)(hb->state->buffer_index)*sizeof(heartbeat_record_t));
+     return (int)hb->state->buffer_depth;
   }
   else {
     memcpy(record,
 	   &hb->log[0],
-	   hb->state->buffer_index*sizeof(heartbeat_record_t));
-    return hb->state->buffer_index;
+	   (size_t)hb->state->buffer_index*sizeof(heartbeat_record_t));
+    return (int)hb->state->buffer_index;
   }
 }
 

--- a/src/heartbeat-accuracy-power-shared.c
+++ b/src/heartbeat-accuracy-power-shared.c
@@ -96,7 +96,7 @@ heartbeat_t* heartbeat_acc_pow_init(int64_t window_size,
     heartbeat_finish(hb);
     return NULL;
   }
-  sprintf(hb->filename, "%s/%d", enabled_dir, hb->state->pid);
+  snprintf(hb->filename, sizeof(hb->filename), "%s/%d", enabled_dir, hb->state->pid);
   printf("%s\n", hb->filename);
 
   hb->log = HB_alloc_log(hb->state->pid, buffer_depth);

--- a/src/heartbeat-accuracy-shared.c
+++ b/src/heartbeat-accuracy-shared.c
@@ -56,7 +56,7 @@ heartbeat_t* heartbeat_init(int64_t window_size,
     heartbeat_finish(hb);
     return NULL;
   }
-  sprintf(hb->filename, "%s/%d", enabled_dir, hb->state->pid);
+  snprintf(hb->filename, sizeof(hb->filename), "%s/%d", enabled_dir, hb->state->pid);
   printf("%s\n", hb->filename);
 
   hb->log = HB_alloc_log(hb->state->pid, buffer_depth);

--- a/src/heartbeat-shared.c
+++ b/src/heartbeat-shared.c
@@ -55,7 +55,7 @@ heartbeat_t* heartbeat_init(int64_t window_size,
     heartbeat_finish(hb);
     return NULL;
   }
-  sprintf(hb->filename, "%s/%d", enabled_dir, hb->state->pid);
+  snprintf(hb->filename, sizeof(hb->filename), "%s/%d", enabled_dir, hb->state->pid);
   printf("%s\n", hb->filename);
 
   hb->log = HB_alloc_log(hb->state->pid, buffer_depth);

--- a/src/heartbeat-shared.c
+++ b/src/heartbeat-shared.c
@@ -19,6 +19,7 @@ heartbeat_t* heartbeat_init(int64_t window_size,
                             double min_target,
                             double max_target) {
   int pid = getpid();
+  char* enabled_dir;
 
   heartbeat_t* hb = (heartbeat_t*) malloc(sizeof(heartbeat_t));
   if (hb == NULL) {
@@ -49,11 +50,12 @@ heartbeat_t* heartbeat_init(int64_t window_size,
     hb->text_file = NULL;
   }
 
-  if(getenv("HEARTBEAT_ENABLED_DIR") == NULL) {
+  enabled_dir = getenv("HEARTBEAT_ENABLED_DIR");
+  if(!enabled_dir) {
     heartbeat_finish(hb);
     return NULL;
   }
-  sprintf(hb->filename, "%s/%d", getenv("HEARTBEAT_ENABLED_DIR"), hb->state->pid);
+  sprintf(hb->filename, "%s/%d", enabled_dir, hb->state->pid);
   printf("%s\n", hb->filename);
 
   hb->log = HB_alloc_log(hb->state->pid, buffer_depth);
@@ -64,7 +66,7 @@ heartbeat_t* heartbeat_init(int64_t window_size,
 
   hb->first_timestamp = hb->last_timestamp = -1;
   hb->state->window_size = window_size;
-  hb->window = (int64_t*) malloc(window_size*sizeof(int64_t));
+  hb->window = (int64_t*) malloc((size_t)window_size * sizeof(int64_t));
   if (hb->window == NULL) {
     perror("Failed to malloc window size");
     heartbeat_finish(hb);
@@ -175,7 +177,7 @@ static inline float hb_window_average(heartbeat_t volatile * hb,
   }
   fps = (1.0 / (float) average_time)*1000000000;
 
-  return fps;
+  return (float)fps;
 }
 
 int64_t heartbeat( heartbeat_t* hb, int tag )
@@ -210,7 +212,7 @@ int64_t heartbeat( heartbeat_t* hb, int tag )
     }
     else {
       //printf("In heartbeat - NOT first time stamp - read index = %d\n",hb->state->read_index );
-      int index =  hb->state->buffer_index;
+      int64_t index =  hb->state->buffer_index;
       hb->last_timestamp = time;
       double window_heartrate = hb_window_average(hb, time-old_last_time);
       double global_heartrate =

--- a/src/heartbeat-util-shared.c
+++ b/src/heartbeat-util-shared.c
@@ -107,7 +107,7 @@ int64_t hb_get_history(heartbeat_t volatile * hb,
     // more records were requested than have been created
     memcpy(record,
            &hb->log[0],
-           hb->state->buffer_index * sizeof(heartbeat_record_t));
+           (size_t)hb->state->buffer_index * sizeof(heartbeat_record_t));
     return hb->state->buffer_index;
   }
 
@@ -115,7 +115,7 @@ int64_t hb_get_history(heartbeat_t volatile * hb,
     // the number of records requested do not overflow the circular buffer
     memcpy(record,
            &hb->log[hb->state->buffer_index - n],
-           n * sizeof(heartbeat_record_t));
+		   (size_t)n * sizeof(heartbeat_record_t));
     return n;
   }
 
@@ -124,10 +124,10 @@ int64_t hb_get_history(heartbeat_t volatile * hb,
     // more records were requested than we can support, return what we have
     memcpy(record,
          &hb->log[hb->state->buffer_index],
-         (hb->state->buffer_depth - hb->state->buffer_index) * sizeof(heartbeat_record_t));
+	     (size_t)(hb->state->buffer_depth - hb->state->buffer_index) * sizeof(heartbeat_record_t));
     memcpy(record + hb->state->buffer_depth - hb->state->buffer_index,
            &hb->log[0],
-           hb->state->buffer_index * sizeof(heartbeat_record_t));
+	     (size_t)hb->state->buffer_index * sizeof(heartbeat_record_t));
     return hb->state->buffer_depth;
   }
 
@@ -135,10 +135,10 @@ int64_t hb_get_history(heartbeat_t volatile * hb,
   // still overflows circular buffer, but we don't want all records
   memcpy(record,
          &hb->log[hb->state->buffer_depth + hb->state->buffer_index - n],
-         (n - hb->state->buffer_index) * sizeof(heartbeat_record_t));
+         (size_t)(n - hb->state->buffer_index) * sizeof(heartbeat_record_t));
   memcpy(record + n - hb->state->buffer_index,
          &hb->log[0],
-         hb->state->buffer_index * sizeof(heartbeat_record_t));
+         (size_t)hb->state->buffer_index * sizeof(heartbeat_record_t));
   return n;
 }
 


### PR DESCRIPTION
At several places the compiler complains about potential loss of information, because of interchanged usage of 64-bit and 32-bit integers and doubles.
This is most notable on compilation for both 32-bit and 64-bit systems.
Using explicit casts some of these warning can be suppressed (although the issue is still there!)

Also changed the double call to `getenv("HEARTBEAT_ENABLED_DIR")` so that the result of the first call is stored as a variable
